### PR TITLE
Fix chat overflow and disable auto scroll

### DIFF
--- a/script.js
+++ b/script.js
@@ -156,7 +156,6 @@ function addMessage(text, sender) {
     }
     
     messagesContainer.appendChild(messageDiv);
-    scrollToBottom();
     
     // Add to chat history
     chatHistory.push({ role: sender, text: text, time: time });
@@ -194,7 +193,6 @@ function escapeHtml(text) {
 // Show typing indicator
 function showTypingIndicator() {
     typingIndicator.classList.add('active');
-    scrollToBottom();
 }
 
 // Hide typing indicator
@@ -215,7 +213,6 @@ function showError(message) {
     errorDiv.className = 'error-message';
     errorDiv.textContent = message;
     messagesContainer.appendChild(errorDiv);
-    scrollToBottom();
     
     // Remove error after 5 seconds
     setTimeout(() => {

--- a/style.css
+++ b/style.css
@@ -159,7 +159,6 @@ body {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    scroll-behavior: smooth;
 }
 
 .messages-container::-webkit-scrollbar {
@@ -226,6 +225,7 @@ body {
     animation: fadeInUp 0.3s ease;
     word-wrap: break-word;
     overflow-wrap: break-word;
+    width: 100%;
 }
 
 @keyframes fadeInUp {
@@ -281,8 +281,11 @@ body {
     line-height: 1.4;
     word-wrap: break-word;
     overflow-wrap: break-word;
+    word-break: break-word;
     hyphens: auto;
     max-width: 100%;
+    overflow: hidden;
+    white-space: pre-wrap;
 }
 
 .message.user .message-bubble {
@@ -449,6 +452,26 @@ body {
 .send-button svg {
     width: 20px;
     height: 20px;
+}
+
+/* Code blocks in messages */
+.message-bubble pre {
+    background: rgba(0, 0, 0, 0.05);
+    padding: 8px;
+    border-radius: 4px;
+    overflow-x: auto;
+    margin: 4px 0;
+    max-width: 100%;
+}
+
+.message-bubble code {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 13px;
+    word-break: break-all;
+}
+
+.message-bubble pre code {
+    word-break: normal;
 }
 
 /* Error Message */


### PR DESCRIPTION
Fix overflow in AI responses and remove auto-scroll behavior.

The previous implementation caused horizontal overflow with long AI messages (e.g., code snippets, URLs) and automatically scrolled the chat to the bottom after each new message, which the user found disruptive.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a41f64a-4f80-42c2-a6fd-03a15fc2e79f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a41f64a-4f80-42c2-a6fd-03a15fc2e79f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

