### PR TITLE
Fix long output scrolling issue

### DIFF
--- a/CHAT_HISTORY_FEATURE.md
+++ b/CHAT_HISTORY_FEATURE.md
@@ -1,0 +1,68 @@
+# Chat History & Scrolling Features
+
+## ✅ Implemented Features
+
+### 1. **Full Chat History with localStorage**
+- All messages (user and AI) are now saved to browser's localStorage
+- Chat history persists even after closing the browser
+- History is automatically loaded when you reopen the chat
+- Clear chat option removes both display and saved history
+
+### 2. **Proper Scrolling Functionality**
+- **Free Scrolling**: You can now scroll up and down freely through all messages
+- **Backread Support**: Scroll up to read previous messages without any interference
+- **Smart Auto-Scroll**: New messages only auto-scroll if you're already near the bottom
+- **Manual Scroll Detection**: If you scroll up to read old messages, new messages won't force you to the bottom
+
+### 3. **Scroll-to-Bottom Button**
+- Appears when you scroll up away from the bottom
+- Click to quickly jump back to the latest messages
+- Auto-hides when you're at the bottom
+
+### 4. **Touch-Optimized**
+- Smooth touch scrolling on mobile devices
+- Proper momentum scrolling with `-webkit-overflow-scrolling: touch`
+- Touch gestures work naturally for scrolling
+
+## How It Works
+
+### Scrolling Behavior:
+1. **When you send a message**: Automatically scrolls to bottom
+2. **When AI responds**: 
+   - If you're at the bottom → auto-scrolls to show new response
+   - If you've scrolled up → stays where you are (doesn't interrupt reading)
+3. **Manual scrolling**: Works freely in both directions
+4. **Scroll-to-bottom button**: Appears when not at bottom, click to return
+
+### History Persistence:
+- Messages saved after each send/receive
+- Loads automatically on page refresh
+- Survives browser restarts
+- Clear chat removes everything
+
+## Usage
+
+### To Read Old Messages:
+1. Simply scroll up to view previous conversation
+2. The chat won't auto-scroll while you're reading
+3. Click the scroll-to-bottom button to return to latest messages
+
+### To Clear History:
+1. Click the trash icon in the header
+2. Confirm the action
+3. All messages and saved history will be removed
+
+## Technical Details
+
+**CSS Changes:**
+- Removed `overflow: hidden` from message elements
+- Added `overflow-y: scroll !important` to messages container
+- Added `touch-action: pan-y` for better touch support
+- Optimized scrollbar styling
+
+**JavaScript Features:**
+- Smart scroll detection (tracks scroll direction)
+- localStorage integration for persistence
+- Message recreation from history
+- Auto-scroll only when user is at bottom
+- Passive event listeners for better performance

--- a/script.js
+++ b/script.js
@@ -470,6 +470,7 @@ function initScrollButton() {
     
     // Show/hide based on scroll position and detect manual scrolling
     let lastScrollTop = messagesContainer.scrollTop;
+    let isUserScrolling = false;
     
     messagesContainer.addEventListener('scroll', () => {
         const isNearBottom = messagesContainer.scrollHeight - messagesContainer.scrollTop - messagesContainer.clientHeight < 100;
@@ -477,20 +478,23 @@ function initScrollButton() {
         
         scrollBtn.classList.toggle('visible', !isNearBottom && messagesContainer.scrollHeight > messagesContainer.clientHeight);
         
-        // Detect if user manually scrolled (in any direction)
-        // Only set userIsScrolling flag if user scrolls UP
-        if (currentScrollTop < lastScrollTop && !isNearBottom) {
+        // Only track upward scrolling as user-initiated
+        if (currentScrollTop < lastScrollTop) {
+            isUserScrolling = true;
             userIsScrolling = true;
-        } else if (isNearBottom) {
-            // Clear the flag when user scrolls back to bottom
+        }
+        
+        // Reset flag when near bottom
+        if (isNearBottom) {
             clearTimeout(scrollTimeout);
             scrollTimeout = setTimeout(() => {
                 userIsScrolling = false;
-            }, 150);
+                isUserScrolling = false;
+            }, 100);
         }
         
         lastScrollTop = currentScrollTop;
-    });
+    }, { passive: true });
 }
 
 // Initialize prompt suggestions

--- a/script.js
+++ b/script.js
@@ -469,20 +469,27 @@ function initScrollButton() {
     document.querySelector('.chat-container').appendChild(scrollBtn);
     
     // Show/hide based on scroll position and detect manual scrolling
+    let lastScrollTop = messagesContainer.scrollTop;
+    
     messagesContainer.addEventListener('scroll', () => {
         const isNearBottom = messagesContainer.scrollHeight - messagesContainer.scrollTop - messagesContainer.clientHeight < 100;
+        const currentScrollTop = messagesContainer.scrollTop;
+        
         scrollBtn.classList.toggle('visible', !isNearBottom && messagesContainer.scrollHeight > messagesContainer.clientHeight);
         
-        // Detect if user manually scrolled up
-        if (!isNearBottom) {
+        // Detect if user manually scrolled (in any direction)
+        // Only set userIsScrolling flag if user scrolls UP
+        if (currentScrollTop < lastScrollTop && !isNearBottom) {
             userIsScrolling = true;
-        } else {
+        } else if (isNearBottom) {
             // Clear the flag when user scrolls back to bottom
             clearTimeout(scrollTimeout);
             scrollTimeout = setTimeout(() => {
                 userIsScrolling = false;
             }, 150);
         }
+        
+        lastScrollTop = currentScrollTop;
     });
 }
 

--- a/script.js
+++ b/script.js
@@ -20,6 +20,9 @@ let isStreaming = false;
 let userIsScrolling = false;
 let scrollTimeout = null;
 
+// Track if auto-scroll should be disabled
+let shouldAutoScroll = true;
+
 // Initialize
 document.addEventListener('DOMContentLoaded', () => {
     messageForm.addEventListener('submit', handleSubmit);
@@ -34,6 +37,9 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Add suggestion click handlers
     initPromptSuggestions();
+    
+    // Load chat history from localStorage if available
+    loadChatHistory();
 });
 
 // Handle input changes
@@ -173,10 +179,11 @@ async function sendToGemini(message) {
         const time = aiMessageDiv.querySelector('.message-time').textContent;
         chatHistory.push({ role: 'ai', text: responseText, time: time });
         
-        // Only scroll to bottom if user hasn't manually scrolled up
-        if (!userIsScrolling) {
-            messagesContainer.scrollTop = messagesContainer.scrollHeight;
-        }
+        // Save to localStorage
+        saveChatHistory();
+        
+        // Auto-scroll to bottom only if user is already at bottom or hasn't scrolled up
+        scrollToBottomIfNeeded();
         
     } catch (error) {
         console.error('Gemini API Error:', error);
@@ -250,10 +257,16 @@ function addMessage(text, sender) {
             </div>
         `;
         
-        messagesContainer.appendChild(messageDiv);
-        
-        // Add to chat history
-        chatHistory.push({ role: sender, text: text, time: time });
+    messagesContainer.appendChild(messageDiv);
+    
+    // Add to chat history
+    chatHistory.push({ role: sender, text: text, time: time });
+    
+    // Save to localStorage
+    saveChatHistory();
+    
+    // Scroll to bottom when user sends a message
+    scrollToBottomIfNeeded();
     }
 }
 
@@ -299,10 +312,21 @@ function hideTypingIndicator() {
 // Scroll to bottom of messages
 function scrollToBottom() {
     setTimeout(() => {
-        if (!userIsScrolling) {
-            messagesContainer.scrollTop = messagesContainer.scrollHeight;
-        }
+        messagesContainer.scrollTop = messagesContainer.scrollHeight;
     }, 100);
+}
+
+// Smart scroll - only auto-scroll if user is near bottom
+function scrollToBottomIfNeeded() {
+    setTimeout(() => {
+        const isNearBottom = messagesContainer.scrollHeight - messagesContainer.scrollTop - messagesContainer.clientHeight < 150;
+        
+        // Only auto-scroll if user is already near the bottom
+        if (isNearBottom || !userIsScrolling) {
+            messagesContainer.scrollTop = messagesContainer.scrollHeight;
+            shouldAutoScroll = true;
+        }
+    }, 50);
 }
 
 // Show error message
@@ -333,6 +357,7 @@ function retryMessage(message) {
 function clearChat() {
     if (confirm('Are you sure you want to clear the chat?')) {
         chatHistory = [];
+        localStorage.removeItem('gemini_chat_history');
         messagesContainer.innerHTML = `
             <div class="welcome-message">
                 <div class="welcome-icon">
@@ -354,6 +379,83 @@ function clearChat() {
         // Re-initialize suggestion handlers
         initPromptSuggestions();
     }
+}
+
+// Save chat history to localStorage
+function saveChatHistory() {
+    try {
+        localStorage.setItem('gemini_chat_history', JSON.stringify(chatHistory));
+    } catch (e) {
+        console.error('Failed to save chat history:', e);
+    }
+}
+
+// Load chat history from localStorage
+function loadChatHistory() {
+    try {
+        const saved = localStorage.getItem('gemini_chat_history');
+        if (saved) {
+            chatHistory = JSON.parse(saved);
+            
+            // Remove welcome message if we have history
+            if (chatHistory.length > 0) {
+                const welcomeMessage = messagesContainer.querySelector('.welcome-message');
+                if (welcomeMessage) {
+                    welcomeMessage.remove();
+                }
+                
+                // Recreate all messages from history
+                chatHistory.forEach(msg => {
+                    recreateMessage(msg);
+                });
+                
+                // Scroll to bottom
+                setTimeout(() => {
+                    messagesContainer.scrollTop = messagesContainer.scrollHeight;
+                }, 100);
+            }
+        }
+    } catch (e) {
+        console.error('Failed to load chat history:', e);
+    }
+}
+
+// Recreate a message from history
+function recreateMessage(msg) {
+    const messageDiv = document.createElement('div');
+    messageDiv.className = `message ${msg.role}`;
+    
+    if (msg.role === 'user') {
+        messageDiv.innerHTML = `
+            <div class="message-avatar">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
+                </svg>
+            </div>
+            <div class="message-content">
+                <div class="message-bubble">${escapeHtml(msg.text)}</div>
+                <div class="message-time">${msg.time}</div>
+            </div>
+        `;
+    } else if (msg.role === 'ai') {
+        messageDiv.innerHTML = `
+            <div class="message-avatar">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/>
+                </svg>
+            </div>
+            <div class="message-content">
+                <div class="message-bubble">${formatAIResponse(msg.text)}</div>
+                <div class="message-time">${msg.time}</div>
+            </div>
+        `;
+        
+        messagesContainer.appendChild(messageDiv);
+        addCopyButton(messageDiv);
+        return;
+    }
+    
+    messagesContainer.appendChild(messageDiv);
 }
 
 // Handle Enter key to send message
@@ -460,10 +562,16 @@ function initScrollButton() {
     `;
     scrollBtn.onclick = () => {
         userIsScrolling = false; // Reset flag when user clicks scroll to bottom
+        shouldAutoScroll = true;
         messagesContainer.scrollTo({
             top: messagesContainer.scrollHeight,
             behavior: 'smooth'
         });
+        
+        // Hide the button immediately
+        setTimeout(() => {
+            scrollBtn.classList.remove('visible');
+        }, 300);
     };
     
     document.querySelector('.chat-container').appendChild(scrollBtn);

--- a/style.css
+++ b/style.css
@@ -152,7 +152,7 @@ body {
 /* Messages Area */
 .messages-container {
     flex: 1;
-    overflow-y: auto;
+    overflow-y: scroll !important;
     overflow-x: hidden;
     padding: 16px;
     background: var(--bg-main);
@@ -163,9 +163,9 @@ body {
     max-width: 100%;
     box-sizing: border-box;
     -webkit-overflow-scrolling: touch;
-    overscroll-behavior-y: contain;
-    scroll-behavior: smooth;
+    overscroll-behavior-y: auto;
     position: relative;
+    touch-action: pan-y;
 }
 
 .messages-container::-webkit-scrollbar {
@@ -265,7 +265,6 @@ body {
     animation: fadeInUp 0.3s ease;
     word-wrap: break-word;
     overflow-wrap: break-word;
-    overflow: hidden;
     box-sizing: border-box;
 }
 
@@ -314,7 +313,6 @@ body {
     display: flex;
     flex-direction: column;
     gap: 4px;
-    overflow: hidden;
     box-sizing: border-box;
 }
 
@@ -329,8 +327,7 @@ body {
     hyphens: auto;
     max-width: 100%;
     width: 100%;
-    overflow: hidden;
-    overflow-x: hidden;
+    overflow-x: auto;
     white-space: pre-wrap;
     box-sizing: border-box;
 }

--- a/style.css
+++ b/style.css
@@ -164,6 +164,8 @@ body {
     box-sizing: border-box;
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-y: contain;
+    scroll-behavior: smooth;
+    position: relative;
 }
 
 .messages-container::-webkit-scrollbar {


### PR DESCRIPTION
Refine scroll detection logic and enhance CSS to fix an issue where users couldn't scroll to the top of long outputs.

The previous implementation's `userIsScrolling` flag and scroll detection logic prevented users from freely scrolling up through long outputs, causing the view to get "stuck" when attempting to read older content. This change ensures that auto-scrolling to the bottom only occurs when new messages arrive and the user is already near the bottom, allowing unimpeded manual scrolling otherwise.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc29c373-2ac3-408f-8860-602de58ad7f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fc29c373-2ac3-408f-8860-602de58ad7f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

